### PR TITLE
bbc-basic: Fix a few typos in FNqq_elts.

### DIFF
--- a/bbc-basic/step7_quote.bbc
+++ b/bbc-basic/step7_quote.bbc
@@ -57,7 +57,7 @@ DEF FNstarts_with(ast%, sym$)
   LOCAL a0%
   IF NOT FNis_seq(ast%) THEN =FALSE
   a0% = FNfirst(ast%)
-  IF NOT FNis symbol(a0=) THEN =FALSE
+  IF NOT FNis_symbol(a0%) THEN =FALSE
   =FNunbox_symbol(a0%) = sym$
 
 REM  Map quasiquote, except to splice-unquoted elements.

--- a/bbc-basic/step8_macros.bbc
+++ b/bbc-basic/step8_macros.bbc
@@ -58,7 +58,7 @@ DEF FNstarts_with(ast%, sym$)
   LOCAL a0%
   IF NOT FNis_seq(ast%) THEN =FALSE
   a0% = FNfirst(ast%)
-  IF NOT FNis symbol(a0=) THEN =FALSE
+  IF NOT FNis_symbol(a0%) THEN =FALSE
   =FNunbox_symbol(a0%) = sym$
 
 REM  Map quasiquote, except to splice-unquoted elements.

--- a/bbc-basic/step9_try.bbc
+++ b/bbc-basic/step9_try.bbc
@@ -58,7 +58,7 @@ DEF FNstarts_with(ast%, sym$)
   LOCAL a0%
   IF NOT FNis_seq(ast%) THEN =FALSE
   a0% = FNfirst(ast%)
-  IF NOT FNis symbol(a0=) THEN =FALSE
+  IF NOT FNis_symbol(a0%) THEN =FALSE
   =FNunbox_symbol(a0%) = sym$
 
 REM  Map quasiquote, except to splice-unquoted elements.

--- a/bbc-basic/stepA_mal.bbc
+++ b/bbc-basic/stepA_mal.bbc
@@ -60,7 +60,7 @@ DEF FNstarts_with(ast%, sym$)
   LOCAL a0%
   IF NOT FNis_seq(ast%) THEN =FALSE
   a0% = FNfirst(ast%)
-  IF NOT FNis symbol(a0=) THEN =FALSE
+  IF NOT FNis_symbol(a0%) THEN =FALSE
   =FNunbox_symbol(a0%) = sym$
 
 REM  Map quasiquote, except to splice-unquoted elements.


### PR DESCRIPTION
This fixes the obvious bugs so most of the tests pass.  The one exception is:
```
FAILURES:
SOFT FAILED TEST (line 230): `[unquote 0] -> ['',[unquote 0]]:
    Expected : '\\`\\[unquote\\ 0\\]\r\n\\[unquote\\ 0\\]'
    Got      : '`[unquote 0]\r\n0'
```
